### PR TITLE
Removed non-supported repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.3.9"
+version = "1.3.10"
 group = "ferro2000.immersivetech" 
 archivesBaseName = "immersivetech"
 
@@ -59,19 +59,20 @@ repositories {
         name 'tterrag maven'
         url "http://maven.tterrag.com/"
     }
-	maven { // Redstone Flux
-        name 'CoFH Maven'
-        url "http://maven.covers1624.net/"
+    repositories {//Curseforge maven, in case some other maven goes offline
+        maven {
+            name = "CurseForge"
+            url = "https://minecraft.curseforge.com/api/maven/"
+        }
     }
 }
 
 dependencies {
 	deobfCompile "blusunrize:ImmersiveEngineering:0.12-+"
     deobfCompile "mezz.jei:jei_1.12.2:4.8.5.133"
-    deobfCompile "elucent:albedo:2.0-SNAPSHOT"
+    deobfCompile "albedo:albedo:0.1.3"
 	compileOnly "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.+"//1.1x-1.4.4-55
     compileOnly "mcp.mobius.waila:Hwyla:1.8.20-B35_1.12"
-	compileOnly "cofh:RedstoneFlux:1.12-2.+:deobf"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.3.10"
+version = "1.3.9"
 group = "ferro2000.immersivetech" 
 archivesBaseName = "immersivetech"
 
@@ -51,10 +51,6 @@ repositories {
     maven { // Albedo Lights
         url 'https://repo.elytradev.com/'
     }
-	maven { // HWYLA
-        name "TehNuts WAILA fork"
-        url "http://tehnut.info/maven"
-    }
     maven { // TOP
         name 'tterrag maven'
         url "http://maven.tterrag.com/"
@@ -72,7 +68,6 @@ dependencies {
     deobfCompile "mezz.jei:jei_1.12.2:4.8.5.133"
     deobfCompile "albedo:albedo:0.1.3"
 	compileOnly "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.+"//1.1x-1.4.4-55
-    compileOnly "mcp.mobius.waila:Hwyla:1.8.20-B35_1.12"
 }
 
 processResources {


### PR DESCRIPTION
HWYLA repo has been removed as it's maven is no longer supported. Same with Redstone Flux by CoFH, but it's redundant and isn't needed to compile the source code.